### PR TITLE
made badge link to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![ci workflow](https://github.com/pdtpartners/nix-snapshotter/actions/workflows/ci.yml/badge.svg)
+[![ci workflow](https://github.com/pdtpartners/nix-snapshotter/actions/workflows/ci.yml/badge.svg)](https://github.com/pdtpartners/nix-snapshotter/actions?query=workflow%3ACI)
 # nix-snapshotter
 
 Containerd remote snapshotter that prepares container rootfs from nix store directly.


### PR DESCRIPTION
The CI passing badge now points to the GitHub actions workflow page. I looked into make the badge point directly to each run but it seems like quite a lot of effort and requires to CI to make it's own commits to the README so I didn't think it was worth it. 