### PR TITLE
Migrate flake to flake-parts and use direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 # nix
 result*
 
+# direnv
+.direnv/
+
 # nix-snapshotter
 root/
 out/

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ There is an example container image for use with this snapshotter pushed to Dock
 There is a `Makefile` for testing locally. Though it requires a development
 environment where you have access to root.
 
-In on terminal, use `nix develop` to enter a development environment with
-everything necessary to run nix-snapshotter. Then run `make start-containerd`
-to start the container supervisor. This containerd will be configured to
-use proxy plugin `nix` for the snapshotter.
+If you have [direnv](https://github.com/direnv/direnv), run `direnv allow` to enter a development environment,
+otherwise run `nix develop` in each of the terminals you'll have to manage.
+Then, inside the development environment run `make start-containerd` to start
+the container supervisor. This containerd will be configured to use proxy plugin
+`nix` for the snapshotter.
 
 ```sh
-$ nix develop
 $ make start-containerd
 ```
 
@@ -63,7 +63,6 @@ Then in another terminal, start `nix-snapshotter`, a GRPC service that
 implements a containerd snapshotter.
 
 ```sh
-$ nix develop
 $ make start-nix-snapshotter
 ```
 
@@ -71,14 +70,12 @@ In a final terminal, `make run` will use the CRI interface to pull the
 prebuilt `hinshun/hello:nix` image and run it.
 
 ```sh
-$ nix develop
 $ make run
 Hello, world!
 ```
 
 A more complicated example is `hinshun/redis:nix`:
 ```
-$ nix develop
 $ make run-redis
 1:C 18 Dec 2022 22:46:12.876 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
 1:C 18 Dec 2022 22:46:12.876 # Redis version=7.0.5, bits=64, commit=00000000, modified=0, pid=1, just started

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1690933134,
+        "narHash": "sha256-ab989mN63fQZBFrkk4Q8bYxQCktuHmBIBqUG1jl6/FQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "59cf3f1447cfc75087e7273b04b31e689a8599fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1688590700,
@@ -17,6 +37,7 @@
     },
     "root": {
       "inputs": {
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,93 +3,15 @@
 
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-unstable";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs }:
-    let
-      # to work with older version of flakes
-      lastModifiedDate = self.lastModifiedDate or self.lastModified or "19700101";
-
-      # Generate a user-friendly version number.
-      version = builtins.substring 0 8 lastModifiedDate;
-
-      # System types to support.
-      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
-
-      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
-      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-
-      # Nixpkgs instantiated for supported system types.
-      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
-      
-    in
-    rec {
-      # Provide some binary packages for selected system types.
-      packages = forAllSystems (system:
-        let
-          pkgs = nixpkgsFor.${system};
-          utils = (import ./.) { inherit pkgs system; };
-        in
-        rec {
-          nix-snapshotter = utils.nix-snapshotter;
-
-          hello = utils.buildImage {
-            name = "docker.io/hinshun/hello";
-            tag = "nix";
-            config = {
-              entrypoint = ["${pkgs.hello}/bin/hello"];
-            };
-          };
-
-          redis = utils.buildImage {
-            name = "docker.io/hinshun/redis";
-            tag = "nix";
-            config = {
-              entrypoint = [ "${pkgs.redis}/bin/redis-server" ];
-            };
-          };
-
-          redisWithShell = utils.buildImage {
-            name = "docker.io/hinshun/redis-shell";
-            tag = "nix";
-            fromImage = redis;
-            config = {
-              entrypoint = [ "/bin/sh" ];
-            };
-            copyToRoot = pkgs.buildEnv {
-              name = "system-path";
-              pathsToLink = [ "/bin" ];
-              paths = [
-                pkgs.bashInteractive
-                pkgs.coreutils
-                pkgs.redis
-              ];
-            };
-          };
-        });
-
-      devShells = forAllSystems (system:
-        let
-          pkgs = nixpkgsFor.${system};
-        in
-        {
-          default = pkgs.stdenv.mkDerivation {
-            name = "nix-snapshotter";
-            buildInputs = [
-              pkgs.containerd
-              pkgs.cri-tools
-              pkgs.delve
-              pkgs.gdb
-              pkgs.gopls
-              pkgs.golangci-lint
-              pkgs.gotools
-              pkgs.kind
-              pkgs.kubectl
-              pkgs.runc
-            ] ++ packages.${system}.nix-snapshotter.nativeBuildInputs;
-          };
-        });
-
-      defaultPackage = forAllSystems (system: self.packages.${system}.nix-snapshotter);
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" ];
+      imports = [ ./modules ];
     };
 }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,0 +1,7 @@
+{
+  imports = [
+    ./examples.nix
+    ./parts.nix
+    ./snapshotter.nix
+  ];
+}

--- a/modules/examples.nix
+++ b/modules/examples.nix
@@ -1,0 +1,45 @@
+{
+  perSystem = { pkgs, nix-snapshotter-parts, ... }:
+    let
+      inherit (nix-snapshotter-parts)
+        buildImage
+      ;
+
+    in {
+      packages = rec {
+        hello = buildImage {
+          name = "docker.io/hinshun/hello";
+          tag = "nix";
+          config = {
+            entrypoint = ["${pkgs.hello}/bin/hello"];
+          };
+        };
+
+        redis = buildImage {
+          name = "docker.io/hinshun/redis";
+          tag = "nix";
+          config = {
+            entrypoint = [ "${pkgs.redis}/bin/redis-server" ];
+          };
+        };
+
+        redisWithShell = buildImage {
+          name = "docker.io/hinshun/redis-shell";
+          tag = "nix";
+          fromImage = redis;
+          config = {
+            entrypoint = [ "/bin/sh" ];
+          };
+          copyToRoot = pkgs.buildEnv {
+            name = "system-path";
+            pathsToLink = [ "/bin" ];
+            paths = with pkgs; [
+              bashInteractive
+              coreutils
+              redis
+            ];
+          };
+        };
+      };
+  };
+}

--- a/modules/parts.nix
+++ b/modules/parts.nix
@@ -1,0 +1,5 @@
+{
+  perSystem = { pkgs, system, ... }: {
+    _module.args.nix-snapshotter-parts = import ../. { inherit pkgs system; };
+  };
+}

--- a/modules/snapshotter.nix
+++ b/modules/snapshotter.nix
@@ -1,0 +1,29 @@
+{
+  perSystem = { pkgs, nix-snapshotter-parts, ... }:
+    let
+      inherit (nix-snapshotter-parts)
+        nix-snapshotter
+      ;
+
+    in {
+      packages = {
+        inherit nix-snapshotter;
+        default = nix-snapshotter;
+      };
+
+      devShells.default = pkgs.mkShell {
+        packages = [
+          pkgs.containerd
+          pkgs.cri-tools
+          pkgs.delve
+          pkgs.gdb
+          pkgs.golangci-lint
+          pkgs.gopls
+          pkgs.gotools
+          pkgs.kind
+          pkgs.kubectl
+          pkgs.runc
+        ] ++ nix-snapshotter.nativeBuildInputs;
+      };
+    };
+}


### PR DESCRIPTION
Fix #18 

This tidies up our `flake.nix` and paves the path to exposing nixos modules and configurations following modern flake practices.

Also by integrating with `direnv`, we get to skip the `nix develop` step and stay in our host shell!.