### PR TITLE
Directly set virtualisation instead of a vmVariant to properly fix nix flake check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@main
       - name: Run the Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@main
-      # - name: Check Nix Flake #This is disabled as currently nix flake check erroneously fails
-      #   run: nix flake check
+      - name: Check Nix Flake
+        run: nix flake check
       - name: Build package
         run: nix build
 

--- a/modules/nixos/vm.nix
+++ b/modules/nixos/vm.nix
@@ -1,5 +1,9 @@
-{ pkgs, ... }: 
+{ pkgs, modulesPath, ... }:
 {
+  imports = [
+    (modulesPath + "/virtualisation/qemu-vm.nix")
+  ];
+
   nix-snapshotter.enable = true;
 
   nix.settings.experimental-features = [ "nix-command" "flakes" ];
@@ -24,12 +28,11 @@
     };
   };
 
-  virtualisation.vmVariant = {
-    virtualisation = {
-      memorySize = 2048;
-      cores = 4;
-      graphics = false;
-    };
+  virtualisation = {
+    memorySize = 2048;
+    cores = 4;
+    graphics = false;
+    diskImage = null;
   };
 
   services.openssh.enable = true;


### PR DESCRIPTION
Fix #31 

`vmVariant` uses `extendModule` to create a variant of a host NixOS configuration. In our case our NixOS configuratinon is strictly for VM usage so we shouldn't use `vmVariant`. It properly propagates virtualized filesystems and boot loader settings so `nix flake check` is happy (before it propagated only within the variant so it didn't make it to top-level nixos config).