### PR TITLE
Add missing WithNixStoreDir option to main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,7 +121,7 @@ func serve(ctx context.Context, cfg *config.Config) error {
 		return fmt.Errorf("failed to remove %q: %w", cfg.Address, err)
 	}
 
-	sn, err := nix.NewSnapshotter(cfg.Root, "/nix/store")
+	sn, err := nix.NewSnapshotter(cfg.Root, nix.WithNixStoreDir("/nix/store"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Bug introduced by: #52 

Should run `nix run .#test-snapshotter` before you merge until we have NixOS tests running in CI.