### PR TITLE
Add kubernetes service to VM and integration test working end-to-end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       matrix:
         test:
           - snapshotter
+          - kubernetes
     runs-on: nix-snapshotter-runner
     needs: [lint, build]
     if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')

--- a/README.md
+++ b/README.md
@@ -25,11 +25,18 @@ nix run ".#vm"
 nixos login: admin (Ctrl-A then X to quit)
 Password: admin
 
-# Running nix image with nix-snapshotter
+# Running pkgs.hello image with nix-snapshotter
 sudo nerdctl run hinshun/hello:nix
 
-# Running nix image with rootless nix-snapshotter
+# Running pkgs.hello image with rootless nix-snapshotter
 nerdctl run hinshun/hello:nix
+
+# Running pkgs.redis image with kubernetes & nix-snapshotter
+kubectl apply -f /etc/kubernetes/redis.yaml
+
+# A kubernetes service is setup to forward port 30000 to the redis pod, so you
+# can test out redis with a `ping` command.
+redis-cli -p 30000 ping
 ```
 
 ## Running locally

--- a/flake.nix
+++ b/flake.nix
@@ -13,5 +13,6 @@
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [ "x86_64-linux" ];
       imports = [ ./modules ];
+      debug = true;
     };
 }

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -58,5 +58,6 @@ in {
 
     # NixOS tests for nix-snapshotter.
     nixosTests.snapshotter = import ./tests/snapshotter.nix;
+    nixosTests.kubernetes= import ./tests/kubernetes.nix;
   };
 }

--- a/modules/nixos/kubernetes-startup.nix
+++ b/modules/nixos/kubernetes-startup.nix
@@ -1,0 +1,51 @@
+{ lib, config, pkgs, ... }:
+let
+  inherit (config.systemd.services)
+    kube-addon-manager
+  ;
+
+  inherit (config.services)
+    certmgr
+  ;
+
+  cfg = config.services.kubernetes;
+
+  waitFile = filename: toString (pkgs.writeShellScript "wait-file-${filename}" ''
+    while [ ! -f /var/lib/kubernetes/secrets/${filename} ]; do sleep 1; done
+  '');
+
+  waitPort = port: toString (pkgs.writeShellScript "wait-port-${port}" ''
+    while ! ${pkgs.netcat}/bin/nc -z localhost ${port}; do sleep 1; done
+  '');
+
+in {
+  # Fix various startup issues related to kubernetes systemd services to avoid
+  # failures during NixOS VM boot.
+  config = lib.mkMerge [
+    (lib.mkIf (cfg.roles != []) {
+      systemd.services.etcd.preStart = waitFile "etcd.pem";
+      systemd.services.certmgr.preStart = lib.mkForce ''
+        mkdir -p ${cfg.secretsPath}
+        ${waitFile "ca.pem"}
+      '';
+      systemd.services.kube-apiserver = {
+        preStart = waitFile "service-account-key.pem";
+        # Wait for its own securePort to be ready since it doesn't support
+        # systemd notify.
+        postStart = waitPort (toString cfg.apiserver.securePort);
+      };
+    })
+    (lib.mkIf (cfg.addonManager.bootstrapAddons != {}) {
+      systemd.services.kube-addon-manager.preStart =
+        let
+          files = lib.mapAttrsToList (n: v: pkgs.writeText "${n}.json" (builtins.toJSON v))
+            cfg.addonManager.bootstrapAddons;
+
+        in lib.mkForce ''
+          ${waitFile "cluster-admin.pem"}
+          export KUBECONFIG="/etc/${cfg.pki.etcClusterAdminKubeconfig}"
+          ${cfg.package}/bin/kubectl apply -f ${lib.concatStringsSep " \\\n -f " files}
+        '';
+    })
+  ];
+}

--- a/modules/nixos/nix-snapshotter-rootless.nix
+++ b/modules/nixos/nix-snapshotter-rootless.nix
@@ -81,7 +81,7 @@ in {
 
       bindMounts = {
         "$XDG_RUNTIME_DIR/nix-snapshotter".mountPoint = "/run/nix-snapshotter";
-        "$XDG_DATA_HOME/nix-snapshotter".mountPoint = "/var/lib/nix-snapshotter";
+        "$XDG_DATA_HOME/nix-snapshotter".mountPoint = "/var/lib/containerd/io.containerd.snapshotter.v1.nix";
       };
     };
 

--- a/modules/nixos/tests/kubernetes.nix
+++ b/modules/nixos/tests/kubernetes.nix
@@ -1,0 +1,102 @@
+{ pkgs, ... }:
+let
+  registryHost = "127.0.0.1";
+
+  registryPort = 5000;
+
+  redisImageName = "${registryHost}:${toString registryPort}/redis";
+
+  redisNodePort = 30000;
+
+  redisPod = pkgs.writeText "redis-pod.json" (builtins.toJSON {
+    apiVersion = "v1";
+    kind = "Pod";
+    metadata = {
+      name = "redis";
+      labels.name = "redis";
+    };
+    spec.containers = [{
+      name = "redis";
+      image = redisImageName;
+      args = ["--protected-mode" "no"];
+      ports = [{
+        name = "client";
+        containerPort = 6379;
+      }];
+    }];
+  });
+
+  redisService = pkgs.writeText "redis-service.json" (builtins.toJSON {
+    apiVersion = "v1";
+    kind = "Service";
+    metadata.name = "redis-service";
+    spec = {
+      type = "NodePort";
+      selector.name = "redis";
+      ports = [{
+        name = "client";
+        port = 6379;
+        nodePort = redisNodePort;
+      }];
+    };
+  });
+
+in {
+  nodes.machine = { config, nix-snapshotter-parts, ... }:
+    let
+      cfg = config.services.kubernetes;
+
+      wrapKubectl = pkgs.runCommand "wrap-kubectl" {
+        nativeBuildInputs = [ pkgs.makeWrapper ];
+      } ''
+        mkdir -p $out/bin
+        makeWrapper ${pkgs.kubernetes}/bin/kubectl \
+          $out/bin/kubectl \
+          --set KUBECONFIG "/etc/${cfg.pki.etcClusterAdminKubeconfig}"
+      '';
+
+      redisImage = nix-snapshotter-parts.buildImage {
+        name = redisImageName;
+        tag = "latest";
+        config.entrypoint = ["${pkgs.redis}/bin/redis-server"];
+      };
+
+    in {
+      imports = [ ../nix-snapshotter.nix ];
+
+      services.nix-snapshotter.enable = true;
+
+      services.kubernetes = {
+        roles = ["master" "node"];
+        masterAddress = "localhost";
+      };
+
+      services.dockerRegistry = {
+        enable = true;
+        listenAddress = registryHost;
+        port = registryPort;
+      };
+
+      environment.systemPackages = [
+        (redisImage.copyToRegistry { plainHTTP = true; })
+        pkgs.redis
+        wrapKubectl
+      ];
+    };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("docker-registry.service")
+    machine.wait_for_open_port(${toString registryPort})
+    machine.succeed("copy-to-registry")
+
+    machine.wait_until_succeeds("kubectl get node machine | grep -w Ready")
+
+    machine.wait_until_succeeds("kubectl create -f ${redisPod}")
+    machine.wait_until_succeeds("kubectl create -f ${redisService}")
+
+    machine.wait_until_succeeds("kubectl get pod redis | grep Running")
+    machine.wait_until_succeeds("redis-cli -p ${toString redisNodePort} ping")
+  '';
+}

--- a/modules/nixos/vm.nix
+++ b/modules/nixos/vm.nix
@@ -1,27 +1,48 @@
-{ pkgs, modulesPath, ... }:
+{ lib, config, pkgs, modulesPath, ... }:
 {
   imports = [
     # Import qemu-vm directly to avoid using vmVariant since this config
     # is only intended to be used as a VM. Using vmVariant will emit assertion
     # errors regarding `fileSystems."/"` and `boot.loader.grub.device`.
     (modulesPath + "/virtualisation/qemu-vm.nix")
+    ./kubernetes-startup.nix
   ];
 
+  # Enable rootful & rootless nix-snapshotter. This also starts rootful &
+  # rootless containerd respectively.
   services.nix-snapshotter = {
     enable = true;
-    setContainerdSnapshotter = true;
     rootless.enable = true;
+    setContainerdSnapshotter = true;
   };
-  
+
+  # Provision single node kubernetes listening on localhost.
+  services.kubernetes = {
+    roles = ["master" "node"];
+    masterAddress = "localhost";
+  };
+
+  # Allow non-root "admin" user to just use `kubectl`.
+  services.certmgr.specs.clusterAdmin.private_key.owner = "admin";
+  environment.sessionVariables = {
+    KUBECONFIG = "/etc/${config.services.kubernetes.pki.etcClusterAdminKubeconfig}";
+  };
+
+  # Provide an example kubernetes config for redis using a nix-snapshotter
+  # image.
+  environment.etc."kubernetes/redis.yaml".source = ../../script/k8s/redis.yaml;
+
   nix.settings.experimental-features = [ "nix-command" "flakes" ];
 
   environment.systemPackages = with pkgs; [
     containerd
     cri-tools
     git
+    kubectl
     nerdctl
     nix-snapshotter
-    runc
+    redis
+    vim
   ];
 
   users.users = {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	defaultAddress = "/run/nix-snapshotter/nix-snapshotter.sock"
-	defaultRoot    = "/var/lib/nix-snapshotter"
+	defaultRoot    = "/var/lib/containerd/io.containerd.snapshotter.v1.nix"
 )
 
 // Config provides nix-snapshotter configuration data.

--- a/script/k8s/hello.yml
+++ b/script/k8s/hello.yml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: hello
-spec:
-  containers:
-  - name: hello
-    image: docker.io/hinshun/hello:nix

--- a/script/k8s/redis.yaml
+++ b/script/k8s/redis.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redis
+  labels:
+    app.kubernetes.io/name: redis
+spec:
+  containers:
+  - name: redis
+    image: hinshun/redis:nix
+    args: [ "--protected-mode", "no" ]
+    ports:
+      - containerPort: 6379
+        name: client
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-service
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: redis
+  ports:
+  - name: client
+    port: 6379
+    nodePort: 30000


### PR DESCRIPTION
Fix #50 

Sets up single node kubernetes inside the VM that is integrated with containerd + nix-snapshotter.

The integration test can be accessed via `nix run .#test-kubernetes` and is also run on CI.

## Notable changes
- The canonical root dir for a snapshotter nix plugin is `/var/lib/containerd/io.containerd.snapshotter.v1.nix`, this was necessary to get kubernetes to work out of the box if that's the default directory.
- Add integration test including running redis nix-snapshotter image on kubernetes
- Add `modules/nixos/kubernetes-startup.nix` to address various upstream startup issues. Its mostly aesthetic as the systemd services will restart until it recovers successful but we get these ugly failure errors during VM boot