### PR TITLE
Change default.nix to flake-compat and move original to package.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -37,6 +53,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Containerd snapshotter using nix store directly";
+  description = "Containerd snapshotter that understands nix store paths natively.";
 
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-unstable";
@@ -7,12 +7,15 @@
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
   };
 
-  outputs = inputs@{ flake-parts, ... }:
+  outputs = inputs@{ nixpkgs, flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [ "x86_64-linux" ];
       imports = [ ./modules ];
-      debug = true;
     };
 }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -6,6 +6,5 @@
     ./nixosTests.nix
     ./overlays.nix
     ./packages.nix
-    ./parts.nix
   ];
 }

--- a/modules/examples.nix
+++ b/modules/examples.nix
@@ -1,9 +1,8 @@
 {
-  perSystem = {lib, pkgs, nix-snapshotter-parts, ... }:
+  perSystem = { lib, pkgs, ... }:
     let
-      inherit (nix-snapshotter-parts)
+      inherit (pkgs.nix-snapshotter)
         buildImage
-        copyToRegistry
       ;
 
       examples = rec {

--- a/modules/nixos/tests/kubernetes.nix
+++ b/modules/nixos/tests/kubernetes.nix
@@ -42,7 +42,7 @@ let
   });
 
 in {
-  nodes.machine = { config, nix-snapshotter-parts, ... }:
+  nodes.machine = { config, ... }:
     let
       cfg = config.services.kubernetes;
 
@@ -55,7 +55,7 @@ in {
           --set KUBECONFIG "/etc/${cfg.pki.etcClusterAdminKubeconfig}"
       '';
 
-      redisImage = nix-snapshotter-parts.buildImage {
+      redisImage = pkgs.nix-snapshotter.buildImage {
         name = redisImageName;
         tag = "latest";
         config.entrypoint = ["${pkgs.redis}/bin/redis-server"];

--- a/modules/nixos/tests/snapshotter.nix
+++ b/modules/nixos/tests/snapshotter.nix
@@ -12,7 +12,7 @@ let
   nixTag = "nix";
   nixImage = "${imageName}:${nixTag}";
 
-  base = { pkgs, nix-snapshotter-parts, ... }:
+  base = { pkgs, ... }:
     let
       helloTarball = pkgs.dockerTools.buildImage {
         name = imageName;
@@ -20,7 +20,7 @@ let
         config.entrypoint = ["${pkgs.hello}/bin/hello"];
       };
 
-      hello-nix = nix-snapshotter-parts.buildImage {
+      hello-nix = pkgs.nix-snapshotter.buildImage {
         name = imageName;
         tag = nixTag;
         config.entrypoint = ["${pkgs.hello}/bin/hello"];

--- a/modules/nixosTests.nix
+++ b/modules/nixosTests.nix
@@ -19,7 +19,7 @@ in {
     };
   };
 
-  config.perSystem = { config, pkgs, nix-snapshotter-parts, ... }:
+  config.perSystem = { config, pkgs, ... }:
     let
       evalTest = name: module:
         (lib.nixos.evalTest {
@@ -29,9 +29,6 @@ in {
           ];
           hostPkgs = pkgs;
           node.pkgs = pkgs;
-          extraBaseModules = {
-            _module.args = { inherit nix-snapshotter-parts; };
-          };
         }).config.result;
 
       testRigs = lib.mapAttrs (name: module: evalTest name module) config.nixosTests;

--- a/modules/overlays.nix
+++ b/modules/overlays.nix
@@ -1,29 +1,26 @@
 { self, inputs, ... }:
 {
   # Provide overlay to add `nix-snapshotter`.
-  flake.overlays.default = self: super:
-    let parts = import ../. { pkgs = super; system = self.system; };
-    in { inherit (parts) nix-snapshotter; };
+  flake.overlays.default = self: super: {
+    nix-snapshotter = self.callPackage ../package.nix {};
+
+    # Apply patch on containerd to fix `ctr image import` issue not
+    # working with remote snapshotters depending on `WithPullUnpack`
+    # properties.
+    # See: https://github.com/containerd/containerd/pull/9028
+    containerd = super.containerd.overrideAttrs(o: {
+      patches = (o.patches or []) ++ [
+        ../script/patches/containerd-unpacker-wait.patch
+      ];
+    });
+  };
 
   perSystem = { system, ... }: {
     _module.args.pkgs = import inputs.nixpkgs {
       inherit system;
-      overlays = [
-        # Apply default overlay to provide nix-snapshotter for NixOS tests &
-        # configurations.
-        self.overlays.default
-        (self: super: {
-          # Apply patch on containerd to fix `ctr image import` issue not
-          # working with remote snapshotters depending on `WithPullUnpack`
-          # properties.
-          # See: https://github.com/containerd/containerd/pull/9028
-          containerd = super.containerd.overrideAttrs(o: {
-            patches = (o.patches or []) ++ [
-              ../script/patches/containerd-unpacker-wait.patch
-            ];
-          });
-        })
-      ];
+      # Apply default overlay to provide nix-snapshotter for NixOS tests &
+      # configurations.
+      overlays = [ self.overlays.default ];
     };
   };
 }

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -1,32 +1,27 @@
+{ lib, ... }:
 {
-  perSystem = { pkgs, nix-snapshotter-parts, ... }:
-    let
-      inherit (nix-snapshotter-parts)
-        nix-snapshotter
-      ;
-
-    in {
-      packages = {
-        inherit nix-snapshotter;
-        default = nix-snapshotter;
-      };
-
-      devShells.default = pkgs.mkShell {
-        packages = [
-          pkgs.containerd
-          pkgs.cri-tools
-          pkgs.delve
-          pkgs.gdb
-          pkgs.golangci-lint
-          pkgs.gopls
-          pkgs.gotools
-          pkgs.kind
-          pkgs.kubectl
-          pkgs.rootlesskit
-          pkgs.runc
-          pkgs.slirp4netns
-          pkgs.nerdctl
-        ] ++ nix-snapshotter.nativeBuildInputs;
-      };
+  perSystem = { pkgs, ... }: {
+    packages = {
+      inherit (pkgs) nix-snapshotter;
+      default = pkgs.nix-snapshotter;
     };
+
+    devShells.default = pkgs.mkShell {
+      packages = [
+        pkgs.containerd
+        pkgs.cri-tools
+        pkgs.delve
+        pkgs.gdb
+        pkgs.golangci-lint
+        pkgs.gopls
+        pkgs.gotools
+        pkgs.kind
+        pkgs.kubectl
+        pkgs.rootlesskit
+        pkgs.runc
+        pkgs.slirp4netns
+        pkgs.nerdctl
+      ] ++ pkgs.nix-snapshotter.nativeBuildInputs;
+    };
+  };
 }

--- a/modules/parts.nix
+++ b/modules/parts.nix
@@ -1,5 +1,0 @@
-{
-  perSystem = { pkgs, system, ... }: {
-    _module.args.nix-snapshotter-parts = import ../. { inherit pkgs system; };
-  };
-}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,101 @@
+{ lib
+, buildGoModule
+, closureInfo
+, runCommand
+, writeShellScriptBin
+, writeText
+}:
+
+let
+  nix-snapshotter = buildGoModule {
+    pname = "nix-snapshotter";
+    version = "0.0.1";
+    src = lib.cleanSourceWith {
+      src = lib.sourceFilesBySuffices ./. [
+        ".go"
+        "go.mod"
+        "go.sum"
+        ".tar"
+      ];
+    };
+    vendorSha256 = "sha256-l0ttbSToudTT+GloxOZE6ohGIx8/OTq2LFCi1rjk7Ec=";
+    passthru = { inherit buildImage; };
+  };
+
+  buildImage = args@{
+    # The image name when exported.
+    name,
+    # The image tag when exported.
+    tag ? null,
+    # An image that is used as base image of this image.
+    fromImage ? "",
+    # A derivation (or list of derivation) to include in the layer
+    # root. The store path prefix /nix/store/hash-path is removed. The
+    # store path content is then located at the image /.
+    copyToRoot ? null,
+    # An attribute set describing an image configuration as defined in:
+    # https://github.com/opencontainers/image-spec/blob/8b9d41f48198a7d6d0a5c1a12dc2d1f7f47fc97f/specs-go/v1/config.go#L23
+    config ? {},
+  }:
+    let
+      configFile = writeText "config-${baseNameOf name}.json" (builtins.toJSON config);
+      copyToRootList = lib.toList (args.copyToRoot or []);
+      runtimeClosureInfo = closureInfo {
+        rootPaths = [ configFile ] ++ copyToRootList;
+      };
+      copyToRootFile = writeText "copy-to-root-${baseNameOf name}.json" (builtins.toJSON copyToRootList);
+      fromImageFlag = lib.optionalString (fromImage != "") "--from-image ${fromImage}";
+      image = let
+        imageName = lib.toLower name;
+        imageTag =
+          if tag != null
+          then tag
+          else
+          builtins.head (lib.strings.splitString "-" (baseNameOf image.outPath));
+      in runCommand "image-${baseNameOf name}.json"
+      {
+        inherit imageName;
+        passthru = {
+          inherit imageTag;
+          # provide a cheap to evaluate image reference for use with external tools like docker
+          # DO NOT use as an input to other derivations, as there is no guarantee that the image
+          # reference will exist in the store.
+          imageRefUnsafe = builtins.unsafeDiscardStringContext "${imageName}:${imageTag}";
+          copyToRegistry = copyToRegistry image;
+          copyToOCIArchive = copyToOCIArchive image;
+        };
+      }
+      ''
+        ${nix-snapshotter}/bin/nix2container build \
+        ${fromImageFlag} \
+        ${configFile} \
+        ${runtimeClosureInfo}/store-paths \
+        ${copyToRootFile} \
+        $out
+      '';
+    in image;
+
+  copyToRegistry = image: {
+    plainHTTP ? false
+  }:
+    let
+      plainHTTPFlag = if plainHTTP then "--plain-http" else "";
+
+    in writeShellScriptBin "copy-to-registry" ''
+      echo "Copy ${image.imageName}:${image.imageTag} to Docker Registry"
+      ${nix-snapshotter}/bin/nix2container push \
+      ${plainHTTPFlag} \
+      ${image} \
+      ${image.imageName}:${image.imageTag}
+    '';
+
+  copyToOCIArchive = image: {}:
+    runCommand "${baseNameOf image.imageName}.tar" {} ''
+      echo "Copy ${image.imageName}:${image.imageTag} to OCI archive"
+      ${nix-snapshotter}/bin/nix2container export \
+      ${image} \
+      ${image.imageName}:${image.imageTag} \
+      $out
+    '';
+
+in nix-snapshotter


### PR DESCRIPTION
- Remove nix-snapshotter-parts and rely on overlay only
- Overlay uses callPackage to allow other overlays to easily override nix-snapshotter
- Move buildImage as passthru in nix-snapshotter to easily differentiate between pkgs.dockerTools.buildImage and pkgs.nix-snapshotter.buildImage

Fix #56 