### PR TITLE
Add declarative k8s example for demo purposes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,8 +2,8 @@
 # See: https://github.com/edolstra/flake-compat
 (import
   (
-    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
-    fetchTarball {
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in fetchTarball {
       url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
       sha256 = lock.nodes.flake-compat.locked.narHash;
     }

--- a/examples/declarative-k8s.nix
+++ b/examples/declarative-k8s.nix
@@ -1,0 +1,90 @@
+{ name ? "redis" }:
+
+let
+  nixpkgs =
+    (
+      let lock = builtins.fromJSON (builtins.readFile ../flake.lock);
+      in fetchTarball {
+        url = "https://github.com/NixOS/nixpkgs/archive/${lock.nodes.nixpkgs.locked.rev}.tar.gz";
+        sha256 = lock.nodes.nixpkgs.locked.narHash;
+      }
+    );
+
+  nix-snapshotter = import ../.;
+
+  config =
+    if name == "redis" then
+      {
+        entrypoint = "redis-server";
+        port = 6379;
+        args = [ "--protected-mode" "no" ];
+        nodePort = 30000;
+      }
+    else
+      {
+        entrypoint = "etcd";
+        port = 2379;
+        args = [
+          "--listen-client-urls"
+          "http://0.0.0.0:2379"
+          "--advertise-client-urls"
+          "http://0.0.0.0:2379"
+        ];
+        nodePort = 30001;
+      };
+
+  inherit (config)
+    entrypoint
+    port
+    args
+    nodePort
+  ;
+
+  pkgs = import nixpkgs {
+    overlays = [ nix-snapshotter.overlays.default ];
+  };
+
+  image = pkgs.nix-snapshotter.buildImage {
+    inherit name;
+    resolvedByNix = true;
+    config = {
+      entrypoint = [ "${pkgs.${name}}/bin/${entrypoint}" ];
+    };
+  };
+
+  pod = pkgs.writeText "${name}-pod.json" (builtins.toJSON {
+    apiVersion = "v1";
+    kind = "Pod";
+    metadata = {
+      inherit name;
+      labels = { inherit name; };
+    };
+    spec.containers = [{
+      inherit name args;
+      image = "nix:0${image}";
+      ports = [{
+        name = "client";
+        containerPort = port;
+      }];
+    }];
+  });
+
+  service = pkgs.writeText "${name}-service.json" (builtins.toJSON {
+    apiVersion = "v1";
+    kind = "Service";
+    metadata.name = "${name}-service";
+    spec = {
+      type = "NodePort";
+      selector = { inherit name; };
+      ports = [{
+        name = "client";
+        inherit port nodePort;
+      }];
+    };
+  });
+
+in pkgs.runCommand "declarative-k8s" {} ''
+  mkdir -p $out/share/k8s
+  cp ${pod} $out/share/k8s/
+  cp ${service} $out/share/k8s/
+''

--- a/modules/nixos/vm.nix
+++ b/modules/nixos/vm.nix
@@ -29,6 +29,7 @@ in {
   nix.settings.experimental-features = [ "nix-command" "flakes" ];
 
   environment.systemPackages = with pkgs; [
+    bat
     containerd
     cri-tools
     git
@@ -37,6 +38,7 @@ in {
     nerdctl
     nix-snapshotter
     redis
+    tree
     vim
   ];
 


### PR DESCRIPTION
For the demo:

```sh
cd examples
nix build -f declarative-k8s.nix --argstr name "redis"
kubectl apply -f ./result/share/k8s
nix build -f declarative-k8s.nix --argstr name "etcd"
kubectl apply -f ./result/share/k8s
```