### PR TITLE
Add flakehub publish workflow

### DIFF
--- a/.github/workflows/flakehub.yml
+++ b/.github/workflows/flakehub.yml
@@ -1,0 +1,29 @@
+name: Publish to FlakeHub
+
+on:
+  push:
+    tags:
+      - "v?[0-9]+.[0-9]+.[0-9]+*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: The existing tag to publish to FlakeHub
+        type: string
+        required: true
+
+jobs:
+  publish-flakehub:
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: "${{ (inputs.tag != null) && format('refs/tags/{0}', inputs.tag) || '' }}"
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/flakehub-push@main
+        with:
+          visibility: public
+          name: pdtpartners/nix-snapshotter
+          tag: "${{ inputs.tag }}"


### PR DESCRIPTION
Using: https://flakehub.com/new

This will make the `pdtpartners/nix-snapshotter` flake listed on FlakeHub.

Our flake will become available under the following references in addition to `github:pdtpartners/nix-snapshotter`:

- Latest stable: `https://flakehub.com/f/pdtpartners/nix-snapshotter/*.tar.gz`
- Specific version: `https://flakehub.com/f/pdtpartners/nix-snapshotter/0.1.0.tar.gz` 