### PR TITLE
fixes nix builder

### DIFF
--- a/pkg/nix/nix.go
+++ b/pkg/nix/nix.go
@@ -55,7 +55,7 @@ func defaultNixBuilder(ctx context.Context, outLink, nixStorePath string) error 
 	} else {
 		args = append(args, "--out-link", outLink)
 	}
-	args = append(args, "nixStorePath")
+	args = append(args, nixStorePath)
 
 	_, err := exec.Command("nix", args...).Output()
 	var exitErr *exec.ExitError


### PR DESCRIPTION
As far as I can tell, the following feature advertised in the `README.md` isn't working:

> Packages can be fetched from a binary cache or built on the fly if necessary.

This PR resolves this!