### PR TITLE
Upgrade k3s version to v1.27.9+k3s1

### DIFF
--- a/modules/flake/overlays.nix
+++ b/modules/flake/overlays.nix
@@ -2,15 +2,26 @@
 {
   # Provide overlay to add `nix-snapshotter`.
   flake.overlays.default = self: super: {
-    nix-snapshotter = self.callPackage ../../package.nix {};
+    nix-snapshotter = self.callPackage ../../package.nix { };
 
-    # Depends on PR merged into main, but not yet in a release tag.
+    # Depends on PR merged into main, but not yet in nixpkgs. Included in 2.0.0-beta.1 and later.
     # See: https://github.com/containerd/containerd/pull/9028
-    containerd = super.containerd.overrideAttrs(o: {
+    containerd = super.containerd.overrideAttrs (o: {
       src = self.fetchFromGitHub {
         inherit (o.src) owner repo;
         rev = "779875a057ff98e9b754371c193fe3b0c23ae7a2";
         hash = "sha256-sXMDMX0QPbnFvRYrAP+sVFjTI9IqzOmLnmqAo8lE9pg=";
+      };
+    });
+
+
+    # Fixes https://github.com/pdtpartners/nix-snapshotter/issues/102 due to 23.11 only supporting v1.27.6 while we need v1.27.7. 
+    # Remove once we upgrade to the next stable release.
+    k3s = super.k3s.overrideAttrs (oldAttrs: {
+      k3sRepo = super.fetchgit {
+        url = "https://github.com/k3s-io/k3s";
+        rev = "v1.27.9+k3s1";
+        sha256 = "sha256-Zr9Zp9pi7S3PCTveiuSb0RebiGZrxxKC+feTAWO47Js=";
       };
     });
   };

--- a/modules/nixos/k3s.nix
+++ b/modules/nixos/k3s.nix
@@ -13,6 +13,7 @@ in {
     enable = true;
     extraFlags = toString [
       "--container-runtime-endpoint unix:///run/containerd/containerd.sock"
+      "--image-service-endpoint unix:///run/nix-snapshotter/nix-snapshotter.sock"
     ];
   };
 


### PR DESCRIPTION
Added an overlay to upgrade k3s to the version on unstable so that we get the bug fix mentioned in #102 . Also removed the containerd overlay as the 23.11 contains the fix we required.  

closes #102 