### PR TITLE
fixes k3s image pulling

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,27 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1705496572,
+        "narHash": "sha256-rPIe9G5EBLXdBdn9ilGc0nq082lzQd0xGGe092R/5QE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "842d9d80cfd4560648c785f8a4e6f3b096790e19",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-23.11";
+    nixpkgs-unstable.url = "nixpkgs/nixos-unstable";
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";

--- a/modules/flake/overlays.nix
+++ b/modules/flake/overlays.nix
@@ -16,11 +16,15 @@
   };
 
   perSystem = { system, ... }: {
-    _module.args.pkgs = import inputs.nixpkgs {
+    _module.args.pkgs = let
+      # Creates a k3s overlay to get a recent version with the --image-service-endpoint flag
+      nixpkgs-unstable = import inputs.nixpkgs-unstable {inherit system;};
+      k3sOverlay = final: prev: {k3s = nixpkgs-unstable.k3s;};
+    in import inputs.nixpkgs {
       inherit system;
       # Apply default overlay to provide nix-snapshotter for NixOS tests &
       # configurations.
-      overlays = [ self.overlays.default ];
+      overlays = [ self.overlays.default k3sOverlay];
     };
   };
 }

--- a/modules/nixos/k3s.nix
+++ b/modules/nixos/k3s.nix
@@ -13,6 +13,7 @@ in {
     enable = true;
     extraFlags = toString [
       "--container-runtime-endpoint unix:///run/containerd/containerd.sock"
+      "--image-service-endpoint unix:///run/nix-snapshotter/nix-snapshotter.sock"
     ];
   };
 


### PR DESCRIPTION
Closes issue https://github.com/pdtpartners/nix-snapshotter/issues/102 by upgrading `k3s` to a recent version that supports the `--image-service-endpoint` flag. Then, we use that flag to point `k3s` to `nix-snapshotter`.