### PR TITLE
have `k3s` use `nix-snapshotter`

### DIFF
--- a/modules/nixos/k3s.nix
+++ b/modules/nixos/k3s.nix
@@ -11,9 +11,10 @@ let
 in {
   services.k3s = {
     enable = true;
-    extraFlags = toString [
-      "--container-runtime-endpoint unix:///run/containerd/containerd.sock"
-    ];
+    configPath = pkgs.writeText "k3s_config.yaml" ''
+      container-runtime-endpoint: "unix:///run/containerd/containerd.sock"
+      image-service-endpoint: "unix:///run/nix-snapshotter/nix-snapshotter.sock"
+    '';
   };
 
   virtualisation.containerd = {


### PR DESCRIPTION
Closes https://github.com/pdtpartners/nix-snapshotter/issues/102

This PR is simpler than both #108 and #109 which upgraded `k3s` to a recent version that supports the `--image-service-endpoint` flag. It turns out we can simply write out the config file for `k3s` instead of relying on the new flag.