### PR TITLE
Add NewExternalNixBuilder to enable config-level changing of NixBuilder

### DIFF
--- a/main.go
+++ b/main.go
@@ -131,7 +131,12 @@ func serve(ctx context.Context, cfg *config.Config) error {
 		runtime.RegisterImageServiceServer(rpc, imageService)
 	}
 
-	sn, err := nix.NewSnapshotter(cfg.Root)
+	var snapshotterOpts []nix.SnapshotterOpt
+	if cfg.ExternalBuilder != "" {
+		snapshotterOpts = append(snapshotterOpts, nix.WithNixBuilder(nix.NewExternalBuilder(cfg.ExternalBuilder)))
+	}
+
+	sn, err := nix.NewSnapshotter(cfg.Root, snapshotterOpts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,9 +19,10 @@ var (
 
 // Config provides nix-snapshotter configuration data.
 type Config struct {
-	Address      string             `toml:"address"`
-	Root         string             `toml:"root"`
-	ImageService ImageServiceConfig `toml:"image_service"`
+	Address         string             `toml:"address"`
+	Root            string             `toml:"root"`
+	ExternalBuilder string             `toml:"external_builder"`
+	ImageService    ImageServiceConfig `toml:"image_service"`
 }
 
 type ImageServiceConfig struct {

--- a/pkg/nix/nix.go
+++ b/pkg/nix/nix.go
@@ -74,3 +74,17 @@ func defaultNixBuilder(ctx context.Context, outLink, nixStorePath string) error 
 	}
 	return err
 }
+
+// NewExternalBuilder returns a NixBuilder from an external executable with
+// two arguments: an out-link path, and a Nix store path.
+func NewExternalBuilder(name string) NixBuilder {
+	return func(ctx context.Context, outLink, nixStorePath string) error {
+		out, err := exec.Command(name, outLink, nixStorePath).CombinedOutput()
+		if err != nil {
+			log.G(ctx).
+				WithField("nixStorePath", nixStorePath).
+				Errorf("Failed to run external nix builder: %s\n%s", err, string(out))
+		}
+		return err
+	}
+}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -77,7 +77,13 @@ func init() {
 			}
 
 			ic.Meta.Exports["root"] = root
-			return nix.NewSnapshotter(root)
+
+			var snapshotterOpts []nix.SnapshotterOpt
+			if cfg.ExternalBuilder != "" {
+				snapshotterOpts = append(snapshotterOpts, nix.WithNixBuilder(nix.NewExternalBuilder(cfg.ExternalBuilder)))
+			}
+
+			return nix.NewSnapshotter(root, snapshotterOpts...)
 		},
 	})
 }


### PR DESCRIPTION
Since rootless k3s needs an embedded nix-snapshotter, we need a config-level way of modifying the `NixBuilder` for internal use. We want to avoid maintaining a long-lived branch of k3s only to pass in a `WithNixBuilder`, so I've exposed it in the nix-snapshotter config as `external_builder`.

Includes an integration test.