### PR TITLE
Prepare for 0.1.2 release

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -9,7 +9,7 @@
 let
   nix-snapshotter = buildGoModule {
     pname = "nix-snapshotter";
-    version = "0.1.1";
+    version = "0.1.2";
     src = lib.cleanSourceWith {
       src = lib.sourceFilesBySuffices ./. [
         ".go"


### PR DESCRIPTION
Preparing to cut tag `v0.1.2` for plugin capability & PR to k3s for nix-snapshotter support.