### PR TITLE
Improve compatibility for home-manager modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ easy installation.
       nix-snapshotter.homeModules.default
     ];
 
-    // # (2) Add overlay.
+    # (2) Add overlay.
     nixpkgs.overlays = [ nix-snapshotter.overlays.default ];
 
     # (3) Enable service.
@@ -255,7 +255,7 @@ easy installation.
   in {
     imports = [
       ./hardware-configuration.nix
-      # (1) Import home-manager module.
+      # (1) Import nixos module.
       nix-snapshotter.nixosModules.default
     ];
 

--- a/modules/common/containerd.nix
+++ b/modules/common/containerd.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, ... }:
+{ pkgs, lib, ... }:
 let
   inherit (lib)
     mkEnableOption
@@ -10,8 +10,6 @@ let
     GOOS
     GOARCH
   ;
-
-  cfg = config.virtualisation.containerd;
 
   options = {
     k3sIntegration = mkEnableOption "K3s integration";
@@ -82,13 +80,6 @@ in {
         ;
       };
       internal = true;
-    };
-  };
-
-  config = lib.mkIf cfg.enable {
-    virtualisation.containerd = lib.mkIf cfg.nixSnapshotterIntegration {
-      setSnapshotter = lib.mkDefault "nix";
-      settings = mkNixSnapshotterSettings;
     };
   };
 }

--- a/modules/flake/overlays.nix
+++ b/modules/flake/overlays.nix
@@ -9,7 +9,8 @@
       # See: https://github.com/containerd/containerd/pull/9028
       containerd = super.containerd.overrideAttrs(o: {
         src = self.fetchFromGitHub {
-          inherit (o.src) owner repo;
+          owner = "containerd";
+          repo = "containerd";
           rev = "779875a057ff98e9b754371c193fe3b0c23ae7a2";
           hash = "sha256-sXMDMX0QPbnFvRYrAP+sVFjTI9IqzOmLnmqAo8lE9pg=";
         };

--- a/modules/nixos/containerd.nix
+++ b/modules/nixos/containerd.nix
@@ -65,6 +65,12 @@ in {
         };
       };
     })
+    (lib.mkIf cfg.nixSnapshotterIntegration {
+      virtualisation.containerd = {
+        setSnapshotter = lib.mkDefault "nix";
+        settings = cfg.lib.mkNixSnapshotterSettings;
+      };
+    })
     (lib.mkIf (cfg.k3sIntegration && cfg.nixSnapshotterIntegration) {
       services.k3s.moreFlags = [
         "--image-service-endpoint unix:///run/nix-snapshotter/nix-snapshotter.sock"


### PR DESCRIPTION
- Fixes some typos in the README
- Home Manager doesn't have `config.virtualisation.containerd` (since it requires root), but #115 introduced a `./modules/common/containerd.nix` dependency, so we move it to `./modules/nixos/containerd.nix` instead.