### PR TITLE
Add support for gVisor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           - k3s
           - k3s-external
           - k3s-rootless
+          - gvisor
     needs: [lint, build]
     if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     steps:

--- a/modules/nixos/containerd-rootless.nix
+++ b/modules/nixos/containerd-rootless.nix
@@ -11,7 +11,7 @@ in {
     ../common/containerd-rootless.nix
   ];
 
-  config = lib.mkIf cfg.enable  {
+  config = lib.mkIf cfg.enable {
     environment.extraInit = ''
       if [ -z "$CONTAINERD_ADDRESS" ]; then
         export CONTAINERD_ADDRESS="${cfg.setAddress}"

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -87,5 +87,6 @@ in {
     nixosTests.k3s = import ./tests/k3s.nix;
     nixosTests.k3s-external = import ./tests/k3s-external.nix;
     nixosTests.k3s-rootless = import ./tests/k3s-rootless.nix;
+    nixosTests.gvisor = import ./tests/gvisor.nix;
   };
 }

--- a/modules/nixos/tests/gvisor.nix
+++ b/modules/nixos/tests/gvisor.nix
@@ -1,0 +1,122 @@
+{ lib, pkgs, ... }:
+let
+  redis = pkgs.nix-snapshotter.buildImage {
+    name = "ghcr.io/pdtpartners/redis";
+    tag = "latest";
+    copyToRoot = [
+      pkgs.util-linux
+    ];
+    config = {
+      Entrypoint = [ "${pkgs.redis}/bin/redis-server" ];
+      Cmd = [ "--protected-mode" "no" ];
+    };
+  };
+
+  common = {
+    environment.systemPackages = [
+      pkgs.nerdctl
+      pkgs.redis
+    ];
+
+    nix.settings.experimental-features = [ "nix-command" ];
+  };
+
+in {
+  nodes = {
+    rootful = {
+      imports = [
+        common
+      ];
+
+      virtualisation.containerd = {
+        enable = true;
+        nixSnapshotterIntegration = true;
+        gVisorIntegration = true;
+      };
+
+      services.nix-snapshotter = {
+        enable = true;
+      };
+
+      services.preload-containerd = {
+        enable = true;
+        targets = [{
+          archives = [ redis ];
+        }];
+      };
+    };
+
+    rootless = {
+      imports = [
+        common
+      ];
+
+      virtualisation.containerd.rootless = {
+        enable = true;
+        nixSnapshotterIntegration = true;
+        gVisorIntegration = true;
+      };
+
+      services.nix-snapshotter.rootless = {
+        enable = true;
+      };
+
+      services.preload-containerd.rootless = {
+        enable = true;
+        targets = [{
+          archives = [ redis ];
+          address = "$XDG_RUNTIME_DIR/containerd/containerd.sock";
+        }];
+      };
+
+      users.users.alice = {
+        uid = 1000;
+        isNormalUser = true;
+      };
+
+      environment.variables = {
+        XDG_RUNTIME_DIR = "/run/user/1000";
+      };
+    };
+  };
+
+  testScript = { nodes, ... }:
+    let
+      sudo_su = lib.concatStringsSep " " [
+        "sudo"
+        "--preserve-env=XDG_RUNTIME_DIR,CONTAINERD_ADDRESS,CONTAINERD_SNAPSHOTTER"
+        "-u"
+        "alice"
+      ];
+
+    in ''
+      def test(machine, sudo_su = ""):
+        if sudo_su == "":
+          machine.wait_for_unit("nix-snapshotter.service")
+          machine.wait_for_unit("containerd.service")
+          machine.wait_for_unit("preload-containerd.service")
+        else:
+          machine.succeed("loginctl enable-linger alice")
+          wait_for_user_unit(machine, "nix-snapshotter.service")
+          wait_for_user_unit(machine, "containerd.service")
+          wait_for_user_unit(machine, "preload-containerd.service")
+
+        with subtest(f"{machine.name}: Run redis using runtime runsc"):
+          machine.succeed(f"{sudo_su} nerdctl run -d --name redis --runtime runsc -p 30000:6379 --cap-add syslog ghcr.io/pdtpartners/redis")
+
+        with subtest(f"{machine.name}: Ensure that gVisor is active"):
+          out = machine.succeed(f"{sudo_su} nerdctl exec redis dmesg | grep -i gvisor")
+          assert "Starting gVisor" in out
+
+        with subtest(f"{machine.name}: Ensure that redis is healthy"):
+          out = machine.wait_until_succeeds(f"{sudo_su} redis-cli -p 30000 ping")
+          assert "PONG" in out
+
+      def wait_for_user_unit(machine, service, user = "alice"):
+        machine.wait_until_succeeds(f"systemctl --user --machine={user}@ is-active {service}")
+
+      start_all()
+      test(rootful)
+      test(rootless, "${sudo_su}")
+    '';
+}


### PR DESCRIPTION
Fix #121 

I’m keen on getting gVisor working because that opens the door for other runtimes. Turns out, we can get it working for both rootful & rootless modes.

See: https://gvisor.dev/docs/user_guide/containerd/quick_start/

## New options

- New options for `containerd` & `containerd.rootless`

```nix
virtualisation.containerd = {
  enable = true;
  nixSnapshotterIntegration = true;
  # Configures containerd settings for gVisor & adds pkgs.gvisor to containerd PATH
  # Also wraps `runsc` appropriately for rootless mode.
  # See: https://github.com/google/gvisor/issues/311#issuecomment-1121668954
  gVisorIntegration = true;
  # Sets the default CRI runtime to `runsc`
  defaultRuntime = "runsc";
}
```