### PR TITLE
k3s: use default buildGoModule

### DIFF
--- a/modules/flake/overlays.nix
+++ b/modules/flake/overlays.nix
@@ -25,9 +25,7 @@
         nix-snapshotter
       ;
 
-      k3s = (self.callPackage ./k3s {
-        buildGoModule = self.buildGo120Module;
-      }).k3s_1_27;
+      k3s = (self.callPackage ./k3s { }).k3s_1_27;
     };
 
   perSystem = { system, ... }: {


### PR DESCRIPTION
buildGo120Module is not available for NixOS 24.05