### PR TITLE
k3s: use default buildGoModule [V2] 

### DIFF
--- a/modules/flake/k3s/builder.nix
+++ b/modules/flake/k3s/builder.nix
@@ -50,6 +50,7 @@ lib:
 , fetchurl
 , fetchzip
 , fetchgit
+, fetchpatch
 , zstd
 , yq-go
 , sqlite
@@ -191,6 +192,11 @@ let
       ../patches/k3s-rootless-state-dir.patch
       # See: https://github.com/k3s-io/k3s/pull/9319
       ../patches/k3s-nix-snapshotter.patch
+      # See: https://github.com/k3s-io/k3s/pull/9064
+      (fetchpatch {
+        url = "https://patch-diff.githubusercontent.com/raw/k3s-io/k3s/pull/9064.patch";
+        sha256 = "sha256-xp9nGIalSvDLfccQ+HNQqWT8z2LKH1HfCuaYxieMT94=";
+      })
     ];
 
     nativeBuildInputs = [ pkg-config ];

--- a/modules/flake/overlays.nix
+++ b/modules/flake/overlays.nix
@@ -25,9 +25,7 @@
         nix-snapshotter
       ;
 
-      k3s = (self.callPackage ./k3s {
-        buildGoModule = self.buildGo120Module;
-      }).k3s_1_27;
+      k3s = (self.callPackage ./k3s {}).k3s_1_27;
     };
 
   perSystem = { system, ... }: {


### PR DESCRIPTION
Finishing off the [PR](https://github.com/pdtpartners/nix-snapshotter/pull/138) @ck3d opened. We can patch `k3s` to fix the go 120+ build issue and remove the dependency on the deprecated go builder.