### PR TITLE
fix: add cfg.path to containerd-rootless.sh PATH

### DIFF
--- a/modules/common/containerd-rootless.nix
+++ b/modules/common/containerd-rootless.nix
@@ -88,7 +88,7 @@ let
         name = "containerd-rootless";
         src = ./containerd-rootless.sh;
         inherit containerdArgs;
-        path = lib.makeBinPath [
+        path = lib.makeBinPath ([
           containerd-rootless-child
           pkgs.bash
           pkgs.iproute2
@@ -98,7 +98,7 @@ let
           pkgs.util-linux
           # Need access to newuidmap from "/run/wrappers"
           "/run/wrappers"
-        ];
+        ] ++ cfg.path);
       };
 
       mountSources = lib.concatStringsSep " " (


### PR DESCRIPTION
This fixes #106.

See my comment in https://github.com/pdtpartners/nix-snapshotter/issues/106#issuecomment-2323387539

This PR adds the `++ cfg.path` that I mentioned.

I have tested this change by setting the path in the `virtualisation.containerd.rootless` config, like so:
```
virtualisation.containerd.rootless = {
    enable = true;
    nixSnapshotterIntegration = true;
    path = [
      "/usr"
    ];
  };
```

Since I am running on Ubuntu, I need to add `/usr` to the path (and `containerd-rootless.nix` uses `lib.makeBinPath` which add `/bin`).

The final `containerd-rootless.sh` script's PATH includes `/usr/bin` and now `rootlesskit` succesfully finds `newuidmap` on the PATH.

```bash
export PATH="/nix/store/ycaw9wiw7s3ky5jdih595yjy7wz5vbyf-containerd-rootless-child/bin:/nix/store/4bj2kxdm1462fzcc2i2s4dn33g2angcc-bash-5.2p32/bin:/nix/store/kisggjnkwyhnq1p12wpjyi1dnymhrczg-iproute2-6.10.0/bin:/nix/store/2irps75xqy0gpj4j543kiv7gafhy89yg-libselinux-3.6-bin/bin:/nix/store/9li94qxgjzhldqc4c27d76an41v06sfz-rootlesskit-2.1.0/bin:/nix/store/yjx4kjhgw6hn66bk5ayp2w8s50nvwcyw-slirp4netns-1.3.1/bin:/nix/store/2lx8zljg14lpyicrb41191sayqa7h0pr-util-linux-2.39.4-bin/bin:/run/wrappers/bin:/usr/bin"
```

If you want to test this change, you can use the fork, something like so:
```
    nix-snapshotter = {
      url = "github:isbecker/nix-snapshotter";
      inputs.nixpkgs.follows = "nixpkgs";
    };
```