### PR TITLE
Adding shellcheck static analysis in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         linter:
           - golangci-lint
+          - shellcheck
     steps:
       - uses: actions/checkout@v4
       # - name: Setup Nix

--- a/modules/common/containerd-rootless-child.sh
+++ b/modules/common/containerd-rootless-child.sh
@@ -12,7 +12,7 @@ set -e
 export PATH="@path@"
 
 
-if ! [ -w $HOME ]; then
+if ! [ -w "$HOME" ]; then
     echo "HOME needs to be set and writable"
     exit 1
 fi
@@ -43,7 +43,7 @@ for i in "${!mountSources[@]}"; do
   # The actual files in the parent namespace are *not removed* by this rm command.
   rm -rf "$mountPoint"
 
-  echo >&2 Bind mounting ${mountSource} to ${mountPoint} inside mount namespace
+  echo >&2 Bind mounting "${mountSource}" to "${mountPoint}" inside mount namespace
   mkdir -p "$mountSource" "$mountPoint"
   mount --bind "$mountSource" "$mountPoint"
 done

--- a/modules/common/containerd-rootless.sh
+++ b/modules/common/containerd-rootless.sh
@@ -12,7 +12,7 @@ set -e
 export PATH="@path@"
 
 
-if ! [ -w $XDG_RUNTIME_DIR ]; then
+if ! [ -w "$XDG_RUNTIME_DIR" ]; then
     echo "XDG_RUNTIME_DIR needs to be set and writable"
     exit 1
 fi

--- a/modules/flake/linters.nix
+++ b/modules/flake/linters.nix
@@ -6,6 +6,9 @@
         golangci-lint = pkgs.writeScriptBin "golangci-lint" ''
           ${pkgs.golangci-lint}/bin/golangci-lint run -v
         '';
+        shellcheck = pkgs.writeScriptBin "shellcheck" ''
+          ${pkgs.shellcheck}/bin/shellcheck -x $(find . -name "*.sh" -type f)
+        '';
       };
 
       apps =

--- a/script/kind/usr/local/bin/kind-entrypoint.sh
+++ b/script/kind/usr/local/bin/kind-entrypoint.sh
@@ -30,4 +30,4 @@ if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
                > /sys/fs/cgroup/cgroup.subtree_control
 fi
 
-exec $@
+exec "$@"

--- a/script/rootless/common.sh
+++ b/script/rootless/common.sh
@@ -1,4 +1,8 @@
-export REPO_DIR=$(git rev-parse --show-toplevel)
+#!/bin/bash
+set -euo pipefail
+
+REPO_DIR="$(git rev-parse --show-toplevel)"
+export REPO_DIR
 
 export BIN_DIR="${REPO_DIR}/build/bin"
 export CONTAINERD_ADDRESS="${REPO_DIR}/build/containerd/containerd.sock"

--- a/script/rootless/containerd.sh
+++ b/script/rootless/containerd.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# shellcheck disable=SC1091
 source "${BASH_SOURCE%/*}/common.sh"
 
 rootlesskit \
@@ -9,5 +10,5 @@ rootlesskit \
     --copy-up=/run \
     --copy-up=/var/lib \
     --port-driver=slirp4netns \
-    --state-dir=$REPO_DIR/build/rootlesskit-containerd \
+    --state-dir="$REPO_DIR/build/rootlesskit-containerd" \
     sh -c "containerd --config ${CONTAINERD_CONFIG_FILE}"

--- a/script/rootless/create-containerd-config.sh
+++ b/script/rootless/create-containerd-config.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
+# shellcheck disable=SC1091
 source "${BASH_SOURCE%/*}/common.sh"
 
-mkdir -p $(dirname $CONTAINERD_CONFIG_FILE)
-cat <<EOM > $CONTAINERD_CONFIG_FILE
+mkdir -p "$(dirname "$CONTAINERD_CONFIG_FILE")"
+cat <<EOM > "$CONTAINERD_CONFIG_FILE"
 version = 2
 root = "$REPO_DIR/build/containerd/root"
 state = "$REPO_DIR/build/containerd/state"

--- a/script/rootless/create-nerdctl-config.sh
+++ b/script/rootless/create-nerdctl-config.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
+# shellcheck disable=SC1091
 source "${BASH_SOURCE%/*}/common.sh"
 
-mkdir -p $(dirname $NERDCTL_TOML)
-cat <<EOM > $NERDCTL_TOML
+mkdir -p "$(dirname "$NERDCTL_TOML")"
+cat <<EOM > "$NERDCTL_TOML"
 address         = "${REPO_DIR}/build/containerd/containerd.sock"
 snapshotter     = "nix"
 data_root       = "${REPO_DIR}/build/nerdctl/root/"

--- a/script/rootless/create-nix-snapshotter-config.sh
+++ b/script/rootless/create-nix-snapshotter-config.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
+# shellcheck disable=SC1091
 source "${BASH_SOURCE%/*}/common.sh"
 
-mkdir -p $(dirname $NIX_SNAPSHOTTER_CONFIG_FILE)
-cat <<EOM > $NIX_SNAPSHOTTER_CONFIG_FILE
+mkdir -p "$(dirname "$NIX_SNAPSHOTTER_CONFIG_FILE")"
+cat <<EOM > "$NIX_SNAPSHOTTER_CONFIG_FILE"
 address = "${REPO_DIR}/build/nix-snapshotter/nix-snapshotter.sock"
 root    = "${REPO_DIR}/build/containerd/root/io.containerd.snapshotter.v1.nix"
 

--- a/script/rootless/load-image.sh
+++ b/script/rootless/load-image.sh
@@ -2,7 +2,8 @@
 
 image=$1
 
+# shellcheck disable=SC1091
 source "${BASH_SOURCE%/*}/common.sh"
 
-outPath=$(nix build --print-out-paths .#image-${image})
-${BIN_DIR}/nix2container --address $CONTAINERD_ADDRESS load ${outPath}
+outPath=$(nix build --print-out-paths .#image-"${image}")
+"${BIN_DIR}"/nix2container --address "$CONTAINERD_ADDRESS" load "${outPath}"

--- a/script/rootless/nerdctl.sh
+++ b/script/rootless/nerdctl.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# shellcheck disable=SC1091
 source "${BASH_SOURCE%/*}/common.sh"
 
 nerdctl "$@"

--- a/script/rootless/nix-snapshotter.sh
+++ b/script/rootless/nix-snapshotter.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# shellcheck disable=SC1091
 source "${BASH_SOURCE%/*}/common.sh"
 
 ./build/bin/nix-snapshotter \

--- a/script/rootless/nsenter.sh
+++ b/script/rootless/nsenter.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
+# shellcheck disable=SC1091
 source "${BASH_SOURCE%/*}/common.sh"
 
 pid=$(cat "$REPO_DIR/build/rootlesskit-containerd/child_pid")
-nsenter -U --preserve-credentials -m -n -t "$pid" $@
+nsenter -U --preserve-credentials -m -n -t "$pid" "$@"


### PR DESCRIPTION
This PR adds [shellcheck](https://github.com/koalaman/shellcheck) static analysis for the shell scripts in this repo and addresses the warnings currently present:
```
In ./script/kind/usr/local/bin/kind-entrypoint.sh line 33:
exec $@
     ^-- SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In ./script/rootless/common.sh line 1:
export REPO_DIR=$(git rev-parse --show-toplevel)
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.
       ^------^ SC2155 (warning): Declare and assign separately to avoid masking return values.
...
...
```