### PR TITLE
chore: Update vendorHash in buildGoModule overlay (Again).

### DIFF
--- a/modules/flake/overlays.nix
+++ b/modules/flake/overlays.nix
@@ -1,4 +1,4 @@
-{ self, inputs, ... }:
+{ self, inputs, lib, ... }:
 {
   # Provide overlay to add `nix-snapshotter`.
   flake.overlays.default = self: super: {
@@ -10,10 +10,11 @@
       buildGoModule = args: super.buildGoModule (args // super.lib.optionalAttrs (args.pname != "k3s-cni-plugins" && args.pname != "k3s-containerd") {
         vendorHash = {
           "sha256-fs9p6ywS5XCeJSF5ovDG40o+H4p4QmEJ0cvU5T9hwuA=" = "sha256-htanp0VOMadzoIyPUT8kOTSb58sz5DHlVBVGbY13ejU=";
+          "sha256-q/cRKuqXuzPcLEYD+BH82ZAc+ZgGIqKWLsM1E4uQsok=" = "sha256-tJBi4b3OGrGbc49+LNx0PXwj9NuvBB55DNvIG1VCMh8=";
         }.${args.vendorHash};
         # Source https://patch-diff.githubusercontent.com/raw/k3s-io/k3s/pull/9319.patch
         # Remove when merged
-        patches = (args.patches or []) ++ [
+        patches = (args.patches or [ ]) ++ [
           ./patches/k3s-nix-snapshotter.patch
         ];
       });


### PR DESCRIPTION
The same thing I did in #144 
Indeed, I pinned nixpkgs version to avoid adding this additional `vendorHash`, but I failed.
I don't know why this happens in my machine.