### PR TITLE
Add support for multiarch image tags

### DIFF
--- a/pkg/nix/image_service.go
+++ b/pkg/nix/image_service.go
@@ -184,8 +184,8 @@ func getNixStorePath(ctx context.Context, ref string, system string) string {
 		":latest",
 	)
 
-	if strings.HasPrefix(path, "/_multiarch/") {
-		path, _ = strings.CutPrefix(path, "/_multiarch/")
+	if strings.HasPrefix(path, "/multiarch/") {
+		path, _ = strings.CutPrefix(path, "/multiarch/")
 
 		pathsPerSystem := map[string]string{}
 

--- a/pkg/nix/image_service.go
+++ b/pkg/nix/image_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/pdtpartners/nix-snapshotter/pkg/nix2container"
 	"google.golang.org/grpc"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+	goruntime "runtime"
 )
 
 var (
@@ -35,6 +37,7 @@ type imageService struct {
 	client             *client.Client
 	imageServiceClient runtime.ImageServiceClient
 	nixBuilder         NixBuilder
+	nixSystem          string
 }
 
 func NewImageService(ctx context.Context, containerdAddr string, opts ...ImageServiceOpt) (runtime.ImageServiceServer, error) {
@@ -47,8 +50,18 @@ func NewImageService(ctx context.Context, containerdAddr string, opts ...ImageSe
 		opt.SetImageServiceOpt(&cfg)
 	}
 
+	var system string
+	if goruntime.GOOS == "linux" && goruntime.GOARCH == "amd64" {
+		system = "x86_64-linux"
+	} else if goruntime.GOOS == "linux" && goruntime.GOARCH == "arm64" {
+		system = "aarch64-linux"
+	} else {
+		log.G(ctx).Fatalf("Cannot derive Nix platform from Go runtime")
+	}
+
 	service := &imageService{
 		nixBuilder: cfg.nixBuilder,
+		nixSystem:  system,
 	}
 
 	go func() {
@@ -112,10 +125,7 @@ func (is *imageService) PullImage(ctx context.Context, req *runtime.PullImageReq
 		resp, err := client.PullImage(ctx, req)
 		return resp, err
 	}
-	archivePath := strings.TrimSuffix(
-		strings.TrimPrefix(ref, nix2container.ImageRefPrefix),
-		":latest",
-	)
+	archivePath := getNixStorePath(ctx, ref, is.nixSystem)
 
 	_, err := os.Stat(archivePath)
 	if errors.Is(err, os.ErrNotExist) {
@@ -165,4 +175,44 @@ func (is *imageService) ImageFsInfo(ctx context.Context, req *runtime.ImageFsInf
 		return nil, ErrNotInitialized
 	}
 	return client.ImageFsInfo(ctx, req)
+}
+
+// getNixStorePath extracts the store path from the image ref.
+func getNixStorePath(ctx context.Context, ref string, system string) string {
+	path := strings.TrimSuffix(
+		strings.TrimPrefix(ref, nix2container.ImageRefPrefix),
+		":latest",
+	)
+
+	if strings.HasPrefix(path, "/_multiarch/") {
+		path, _ = strings.CutPrefix(path, "/_multiarch/")
+
+		pathsPerSystem := map[string]string{}
+
+		storePathRegex := regexp.MustCompile("/nix/store/[0-9a-z]{32}-[-.+_0-9a-zA-Z]+")
+
+		for path != "" {
+			// Extract and remove leading <system>
+			// from <system>/nix/store/<hash>/<other_system>/nix/store/<hash>
+			system := strings.Split(path, "/")[0]
+			path, _ = strings.CutPrefix(path, system)
+
+			// Extract and remove store path
+			// from </nix/store/<hash>>/<system>/nix/store/<hash>
+			systemPath := string(storePathRegex.Find([]byte(path)))
+			path, _ = strings.CutPrefix(path, systemPath)
+			path, _ = strings.CutPrefix(path, "/") // remove leading "/"
+
+			pathsPerSystem[system] = systemPath
+		}
+
+		var ok bool
+		path, ok = pathsPerSystem[system]
+		if !ok {
+			log.G(ctx).Errorf("Failed to extract path from %s", ref)
+		}
+
+	}
+
+	return path
 }

--- a/pkg/nix/image_service_test.go
+++ b/pkg/nix/image_service_test.go
@@ -9,23 +9,23 @@ func TestGetNixStorePath(t *testing.T) {
 	ctx := context.Background()
 
 	// Single arch ref
-	ref := "nix:0/nix/store/02zg1wk37s9k35n5iv850g52dp1ffdxz-nginx-1.24.0"
-	expected := "/nix/store/02zg1wk37s9k35n5iv850g52dp1ffdxz-nginx-1.24.0"
+	ref := "nix:0/nix/store/dbc4mhv2fjbfx8pypx88qgp8nfp392az-nix-image-nginx.tar:latest"
+	expected := "/nix/store/dbc4mhv2fjbfx8pypx88qgp8nfp392az-nix-image-nginx.tar"
 	received := getNixStorePath(ctx, ref, "x86_64-linux")
 	if received != expected {
 		t.Fatalf("Expected %s, received %s", expected, received)
 	}
 
 	// Multi arch ref
-	ref = "nix:0/multiarch/x86_64-linux/nix/store/02zg1wk37s9k35n5iv850g52dp1ffdxz-nginx-1.24.0/aarch64-linux/nix/store/gjilixzvxk9pzilz3ixxamrjqk4mk1jl-nginx-1.24.0"
+	ref = "nix:0/multiarch/aarch64-linux/nix/store/zkw3cjabs8lc8bv4sgnm6x132gm956fc-nix-image-nginx.tar/x86_64-linux/nix/store/dbc4mhv2fjbfx8pypx88qgp8nfp392az-nix-image-nginx.tar:latest"
 
-	expected = "/nix/store/02zg1wk37s9k35n5iv850g52dp1ffdxz-nginx-1.24.0"
+	expected = "/nix/store/dbc4mhv2fjbfx8pypx88qgp8nfp392az-nix-image-nginx.tar"
 	received = getNixStorePath(ctx, ref, "x86_64-linux")
 	if received != expected {
 		t.Fatalf("Expected %s, received %s", expected, received)
 	}
 
-	expected = "/nix/store/gjilixzvxk9pzilz3ixxamrjqk4mk1jl-nginx-1.24.0"
+	expected = "/nix/store/zkw3cjabs8lc8bv4sgnm6x132gm956fc-nix-image-nginx.tar"
 	received = getNixStorePath(ctx, ref, "aarch64-linux")
 	if received != expected {
 		t.Fatalf("Expected %s, received %s", expected, received)

--- a/pkg/nix/image_service_test.go
+++ b/pkg/nix/image_service_test.go
@@ -1,0 +1,33 @@
+package nix
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetNixStorePath(t *testing.T) {
+	ctx := context.Background()
+
+	// Single arch ref
+	ref := "nix:0/nix/store/02zg1wk37s9k35n5iv850g52dp1ffdxz-nginx-1.24.0"
+	expected := "/nix/store/02zg1wk37s9k35n5iv850g52dp1ffdxz-nginx-1.24.0"
+	received := getNixStorePath(ctx, ref, "x86_64-linux")
+	if received != expected {
+		t.Fatalf("Expected %s, received %s", expected, received)
+	}
+
+	// Multi arch ref
+	ref = "nix:0/_multiarch/x86_64-linux/nix/store/02zg1wk37s9k35n5iv850g52dp1ffdxz-nginx-1.24.0/aarch64-linux/nix/store/gjilixzvxk9pzilz3ixxamrjqk4mk1jl-nginx-1.24.0"
+
+	expected = "/nix/store/02zg1wk37s9k35n5iv850g52dp1ffdxz-nginx-1.24.0"
+	received = getNixStorePath(ctx, ref, "x86_64-linux")
+	if received != expected {
+		t.Fatalf("Expected %s, received %s", expected, received)
+	}
+
+	expected = "/nix/store/gjilixzvxk9pzilz3ixxamrjqk4mk1jl-nginx-1.24.0"
+	received = getNixStorePath(ctx, ref, "aarch64-linux")
+	if received != expected {
+		t.Fatalf("Expected %s, received %s", expected, received)
+	}
+}

--- a/pkg/nix/image_service_test.go
+++ b/pkg/nix/image_service_test.go
@@ -17,7 +17,7 @@ func TestGetNixStorePath(t *testing.T) {
 	}
 
 	// Multi arch ref
-	ref = "nix:0/_multiarch/x86_64-linux/nix/store/02zg1wk37s9k35n5iv850g52dp1ffdxz-nginx-1.24.0/aarch64-linux/nix/store/gjilixzvxk9pzilz3ixxamrjqk4mk1jl-nginx-1.24.0"
+	ref = "nix:0/multiarch/x86_64-linux/nix/store/02zg1wk37s9k35n5iv850g52dp1ffdxz-nginx-1.24.0/aarch64-linux/nix/store/gjilixzvxk9pzilz3ixxamrjqk4mk1jl-nginx-1.24.0"
 
 	expected = "/nix/store/02zg1wk37s9k35n5iv850g52dp1ffdxz-nginx-1.24.0"
 	received = getNixStorePath(ctx, ref, "x86_64-linux")


### PR DESCRIPTION
Nix-snaphotter images are referenced by specifying an image in the format of `nix:0<nix store path>`, where the nix store path is the outPath of `pkgs.nix-snapshotter.buildImage {}`.

This MR adds another format that allows specyfing a nix store path to a nix-snapshotter image for each architecture (more specifically, Nix `<architecture>-<os>` system doubles like `x86_64-linux` and `aarch64-darwin`, though I assume nix-snaphotter will only be used on Linux/NixOS).
The format is `nix:0/multiarch/<arch>-<os>/<nix store path>/<another arch>-<os>/<nix store path>`.

This make it possible to create a single Deployment/StatefulSet/etc that can run on any node of a multi-arch Kubernetes cluster, like you can with multi-arch Docker images.

However, unlike multi-arch Docker images, the architecture->image resolution is done directly in the image tag instead of a manifest image. I imagine this could also be done for nix-snaphotter, but it would create a strange situation where the multi-arch manifest would be of one particular system, and reference images of multiple different systems.