### PR TITLE
Add services.nix-snapshotter.extraFlags option

### DIFF
--- a/modules/common/nix-snapshotter-rootless.nix
+++ b/modules/common/nix-snapshotter-rootless.nix
@@ -21,6 +21,7 @@ in {
       configFile
       package
       path
+      extraFlags
       settings
     ;
 

--- a/modules/common/nix-snapshotter.nix
+++ b/modules/common/nix-snapshotter.nix
@@ -33,6 +33,14 @@ let
       '';
     };
 
+    extraFlags = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = lib.mkDoc ''
+        Additional command line flags to pass to nix-snapshotter
+      '';
+    };
+
     settings = mkOption {
       type = settingsFormat.type;
       default = {};
@@ -93,7 +101,11 @@ let
         WantedBy = [ "default.target" ];
       };
 
-      Service.ExecStart = "${nsenter}/bin/containerd-nsenter ${cfg.package}/bin/nix-snapshotter --config ${cfg.configFile}";
+      Service.ExecStart = builtins.concatStringsSep " " ([
+        "${nsenter}/bin/containerd-nsenter"
+        "${cfg.package}/bin/nix-snapshotter"
+        "--config ${cfg.configFile}"
+      ] ++ cfg.extraFlags);
     };
 
 in {

--- a/modules/nixos/nix-snapshotter.nix
+++ b/modules/nixos/nix-snapshotter.nix
@@ -21,6 +21,7 @@ in {
       configFile
       package
       path
+      extraFlags
       settings
     ;
 
@@ -40,7 +41,10 @@ in {
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];
         partOf = [ "containerd.service" ];
-        serviceConfig.ExecStart = "${cfg.package}/bin/nix-snapshotter --config ${cfg.configFile}";
+        serviceConfig.ExecStart = builtins.concatStringsSep " " ([
+          "${cfg.package}/bin/nix-snapshotter"
+          "--config ${cfg.configFile}"
+        ] ++ cfg.extraFlags);
       }
     ];
   };


### PR DESCRIPTION
Some settings (such as log level) are currently not configurable via the TOML config file configurable via the settings option