### PR TITLE
image_service: embed UnimplementedImageServiceServer for gRPC forward-compat

### DIFF
--- a/pkg/nix/image_service.go
+++ b/pkg/nix/image_service.go
@@ -31,6 +31,7 @@ type ImageServiceOpt interface {
 }
 
 type imageService struct {
+	runtime.UnimplementedImageServiceServer
 	mu                 sync.Mutex
 	client             *client.Client
 	imageServiceClient runtime.ImageServiceClient


### PR DESCRIPTION
Embed runtime.UnimplementedImageServiceServer in the imageService struct to satisfy the gRPC forward-compatibility requirement introduced in newer versions of k8s.io/cri-api. Without this, projects that compile nix-snapshotter against k8s >= 1.34 CRI API fail with:

  cannot use service (variable of type *imageService) as
  runtime.ImageServiceServer value: missing method
  mustEmbedUnimplementedImageServiceServer

This is a no-op for existing functionality since all required interface methods are already implemented.

Working on updates to work with latest k3s and containerd including rootless. This is a prerequisite so that we don't have any blockers when going to k3s again.

Working on reviving https://github.com/k3s-io/k3s/pull/9319