### PR TITLE
docs(rootless): document some subtleties in README & package.nix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ easy installation.
             virtualisation.containerd.rootless = {
               enable = true;
               nixSnapshotterIntegration = true;
+              # This may be necessary for non-NixOS systems, as rootless containerd
+              # depends on host commands such as `newuidmap`, which is located under
+              # `/usr/bin` in most linux systems:
+              path = [ "/usr" ];
             };
             services.nix-snapshotter.rootless = {
               enable = true;
@@ -229,6 +233,10 @@ easy installation.
     virtualisation.containerd.rootless = {
       enable = true;
       nixSnapshotterIntegration = true;
+      # This may be necessary for non-NixOS systems, as rootless containerd
+      # depends on host commands such as `newuidmap`, which is located under
+      # `/usr/bin` in most linux systems:
+      path = [ "/usr" ];
     };
     services.nix-snapshotter.rootless = {
       enable = true;

--- a/package.nix
+++ b/package.nix
@@ -37,11 +37,16 @@ let
     # If enabled, the OCI archive will be generated with a special image
     # reference in the format of "nix:0/nix/store/*.tar", which is resolvable
     # by nix-snapshotter if configured as the CRI image-service without a
-    # Docker Registry.
+    # Docker Registry. In this case, the resulting image cannot be imported
+    # with `nerdctl load`. Instead, `passthru.copyToContainerd` can be used
+    # to import the image, and `services.preload-containerd.rootless` can be
+    # configured to preload the images during NixOS / home-manager activation.
     resolvedByNix ? false,
     # An image that is used as base image of this image. Any image can be used
     # as a fromImage, including non-nix images and images built with
-    # pkgs.dockerTools.buildImage.
+    # pkgs.dockerTools.buildImage. Note that compressed images are
+    # not yet supported, so one should set `compressor = "none"` in
+    # `pkgs.dockerTools.buildImage` before passing it to `fromImage`.
     fromImage ? null,
     # A derivation (or list of derivation) to include in the layer
     # root. The store path prefix /nix/store/hash-path is removed. The


### PR DESCRIPTION
This is a magical project! However when setting up the rootless home-manager module, I encountered some subtle issues that are solved in the tracker but not explicitly stated in the documentation. This includes:
- https://github.com/pdtpartners/nix-snapshotter/pull/145
- https://github.com/pdtpartners/nix-snapshotter/issues/129#issuecomment-1962758568
- `fromImage` cannot take compressed images at the moment, so if one is using `dockerTools.buildLayeredImage` one should pass in `compressor = "none"` explicitly.

So I decided to add some relevant comments in README & package.nix on these issues.